### PR TITLE
Update GPIO

### DIFF
--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -24,7 +24,9 @@ class IT8951(DisplayDriver):
     CS_PIN = 8
     BUSY_PIN = 24
 
-    VCOM = 2000
+    # My personal setting for VCM:
+    vcom = 2140
+    #VCOM = 2000
 
     CMD_GET_DEVICE_INFO = [0x03, 0x02]
     CMD_WRITE_REGISTER = [0x00, 0x11]
@@ -241,8 +243,17 @@ class IT8951(DisplayDriver):
             #Don't enable a2 support until that has been implemented.
             #self.supports_a2 = True
 
-        #9.7inch e-Paper HAT(1200,825)
+            #9.7inch e-Paper HAT(1200,825)
         elif len(lut_version) >= 4 and lut_version[:4] == "M841":
+            self.supports_a2 = True
+
+        # Alternative for 6inch HD HAT(1448,1072)
+        elif len(lut_version) >= 12 and lut_version[:12] == "M841_TFAB512":
+
+            #A2 mode is still 6
+            # But will it need four-byte alignment?
+
+            #Should we enable a2 support?
             self.supports_a2 = True
 
         #7.8inch e-Paper HAT(1872,1404)
@@ -279,7 +290,7 @@ class IT8951(DisplayDriver):
         vcom = kwargs.get('vcom', None)
         if vcom:
             self.VCOM = vcom
-            
+
         if self.VCOM != self.get_vcom():
             self.set_vcom(self.VCOM)
             print("VCOM = -%.02fV" % (self.get_vcom() / 1000.0))
@@ -342,7 +353,7 @@ class IT8951(DisplayDriver):
             if not self.in_bpp1_mode:
                 self.write_register(self.REG_UP1SR+2, self.read_register(self.REG_UP1SR+2) | (1<<2) )
                 self.in_bpp1_mode = True
-            
+
             #Also write the black and white color table for 1bpp mode
             self.write_register(self.REG_BGVR, (self.Front_Gray_Val<<8) | self.Back_Gray_Val)
 

--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -25,7 +25,7 @@ class IT8951(DisplayDriver):
     BUSY_PIN = 24
 
     # My personal setting for VCM:
-    vcom = 2140
+    VCOM = 2140
     #VCOM = 2000
 
     CMD_GET_DEVICE_INFO = [0x03, 0x02]

--- a/poetry.lock
+++ b/poetry.lock
@@ -95,7 +95,7 @@ description = "A module to control Raspberry Pi GPIO channels"
 name = "rpi.gpio"
 optional = false
 python-versions = "*"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 category = "main"
@@ -233,7 +233,7 @@ pyhamcrest = [
     {file = "PyHamcrest-2.0.2.tar.gz", hash = "sha256:412e00137858f04bde0729913874a48485665f2d36fe9ee449f26be864af9316"},
 ]
 "rpi.gpio" = [
-    {file = "RPi.GPIO-0.7.0.tar.gz", hash = "sha256:7424bc6c205466764f30f666c18187a0824077daf20b295c42f08aea2cb87d3f"},
+    {file = "RPi.GPIO-0.7.1.tar.gz", hash = "sha256:cd61c4b03c37b62bba4a5acfea9862749c33c618e0295e7e90aa4713fb373b70"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},


### PR DESCRIPTION
Update to GPIO 0.7.1

Fix PyEval_InitThreads deprecation warning for Python 3.9 (issue 188)